### PR TITLE
Refresh auth token and retry on 401 errors

### DIFF
--- a/ttls/client.py
+++ b/ttls/client.py
@@ -33,7 +33,7 @@ import socket
 import time
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from aiohttp import ClientSession
+from aiohttp import ClientSession, ClientResponseError
 
 logger = logging.getLogger("twinkly")
 
@@ -76,25 +76,71 @@ class Twinkly(object):
         if "json" in kwargs:
             logger.info("POST payload %s", kwargs["json"])
         headers = kwargs.pop("headers", self.headers)
-        async with self.session.post(
-            f"{self.base}/{endpoint}", headers=headers, **kwargs
-        ) as r:
-            return await r.json()
+        retry_num = kwargs.pop("retry_num", 0)
+        try:
+            async with self.session.post(
+                f"{self.base}/{endpoint}", headers=headers, **kwargs
+            ) as r:
+                return await r.json()
+        except ClientResponseError as e:
+            if e.status == 401:
+                max_retries = 1
+                if retry_num < max_retries:
+                    retry_num += 1
+                    logger.debug(
+                        f"Invalid token for POST. Refreshing token and attempting retry {retry_num} of {max_retries}."
+                    )
+                    await self.refresh_token()
+                    await self._post(
+                        endpoint, headers=self.headers, retry_num=retry_num, **kwargs
+                    )
+                else:
+                    logger.debug(
+                        f"Invalid token for POST. Maximum retries of {max_retries} exceeded."
+                    )
+                    raise e
+            else:
+                raise e
 
     async def _get(self, endpoint: str, **kwargs) -> Any:
         await self.ensure_token()
         logger.info("GET endpoint %s", endpoint)
         headers = kwargs.pop("headers", self.headers)
-        async with self.session.get(
-            f"{self.base}/{endpoint}", headers=headers, **kwargs
-        ) as r:
-            return await r.json()
+        retry_num = kwargs.pop("retry_num", 0)
+        try:
+            async with self.session.get(
+                f"{self.base}/{endpoint}", headers=headers, **kwargs
+            ) as r:
+                return await r.json()
+        except ClientResponseError as e:
+            if e.status == 401:
+                max_retries = 1
+                if retry_num < max_retries:
+                    retry_num += 1
+                    logger.debug(
+                        f"Invalid token for GET. Refreshing token and attempting retry {retry_num} of {max_retries}."
+                    )
+                    await self.refresh_token()
+                    await self._get(
+                        endpoint, headers=self.headers, retry_num=retry_num, **kwargs
+                    )
+                else:
+                    logger.debug(
+                        f"Invalid token for GET. Maximum retries of {max_retries} exceeded."
+                    )
+                    raise e
+            else:
+                raise e
+
+    async def refresh_token(self) -> str:
+        await self.login()
+        await self.verify_login()
+        logger.debug("Authentication token has been refreshed")
+        return self._token
 
     async def ensure_token(self) -> str:
         if self.expires is None or self.expires <= time.time():
-            logger.debug("Authentication token expired, will refresh")
-            await self.login()
-            await self.verify_login()
+            await self.refresh_token()
         else:
             logger.debug("Authentication token still valid")
         return self._token

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -31,7 +31,7 @@ import logging
 import os
 import socket
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from aiohttp import ClientResponseError, ClientSession
 
@@ -108,7 +108,9 @@ class Twinkly(object):
             else:
                 raise e
 
-    async def _on_status_401(self, request_method, endpoint, exception, **kwargs):
+    async def _on_status_401(
+        self, request_method: Callable, endpoint: str, exception: Exception, **kwargs
+    ) -> Any:
         max_retries = 1
         retry_num = kwargs.pop("retry_num", 0)
         if retry_num < max_retries:

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -140,6 +140,7 @@ class Twinkly(object):
 
     async def ensure_token(self) -> str:
         if self.expires is None or self.expires <= time.time():
+            logger.debug("Authentication token expired, will refresh")
             await self.refresh_token()
         else:
             logger.debug("Authentication token still valid")

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -84,7 +84,9 @@ class Twinkly(object):
                 return await r.json()
         except ClientResponseError as e:
             if e.status == 401:
-                await self._on_status_401(self._post, endpoint, exception=e, **kwargs)
+                await self._on_status_401(
+                    self._post, endpoint, exception=e, retry_num=retry_num, **kwargs
+                )
             else:
                 raise e
 
@@ -100,7 +102,9 @@ class Twinkly(object):
                 return await r.json()
         except ClientResponseError as e:
             if e.status == 401:
-                await self._on_status_401(self._get, endpoint, exception=e, **kwargs)
+                await self._on_status_401(
+                    self._get, endpoint, exception=e, retry_num=retry_num, **kwargs
+                )
             else:
                 raise e
 


### PR DESCRIPTION
While the existing logic ensures that a token exists and is not expired, it does not handle situations where Twinkly may prematurely invalidate a token.  I'm not sure what triggers the premature invalidation, but I find it occurs after 10 or so API calls in a session in my environment.

This PR enhances the GET and POST methods to handle 401 errors due to an invalid token.  When a 401 is received, the auth token is refreshed and the request is resubmitted.

