### PR TITLE
fix: remove print statement

### DIFF
--- a/ttls/client.py
+++ b/ttls/client.py
@@ -164,7 +164,6 @@ class Twinkly(object):
                 **kwargs,
             ) as r:
                 _LOGGER.debug("GET response %d", r.status)
-                print("REPONSE TEXT", await r.text())
                 return await r.json()
         except ClientResponseError as e:
             if e.status == HTTPUnauthorized.status_code:


### PR DESCRIPTION
This is filling up the Home Assistant logs with massive amounts of
output. The _LOGGER.debug statement remains and can be used instead.

Signed-off-by: Avi Miller <me@dje.li>