### PR TITLE
Really post rgbw-colour

### DIFF
--- a/ttls/client.py
+++ b/ttls/client.py
@@ -131,6 +131,12 @@ class Twinkly(object):
     def length(self) -> int:
         return int(self._details["number_of_led"])
 
+    def is_rgbw(self) -> bool:
+        return self._details["led_profile"] == "RGBW"
+
+    def is_rgb(self) -> bool:
+        return self._details["led_profile"] == "RGB"
+
     @property
     def default_mode(self) -> str:
         return self._default_mode
@@ -369,13 +375,17 @@ class Twinkly(object):
             List[TwinklyColourTuple],
         ],
     ) -> None:
+        if not self._details:
+            await self.interview()
         if isinstance(colour, List):
             colour = colour[0]
         if isinstance(colour, Tuple):
             colour = TwinklyColour.from_twinkly_tuple(colour)
+        if not self.is_rgbw():
+            colour.white = None
         await self._post(
             "led/color",
-            json={"red": colour.red, "green": colour.green, "blue": colour.blue},
+            json=colour.as_dict(),
         )
         await self.set_mode("color")
 


### PR DESCRIPTION
It looks like you forgot to include "white" in the set_static_colour-function to actually be able to send rgbw-colours.

Also added at check to see if the device actually supports RGBW before submitting the colour.
It is very crude, and just set `white` to None if a RGBW-colour is to be sent to a RGB-only Twinkly.  It might not give the expected colour if the wrong format is used, but it should at least not confuse the Twinkly. 
The user should probably check the new functions `is_rgb` and `is_rgbw` before manipulating the colours anyway.

We _could_ add something like https://github.com/iamh2o/rgbw_colorspace_converter/ to ensure proper conversion between colorspaces, but I think it is out of the scope at least for now.