### PR TITLE
Remove rgbw-check

### DIFF
--- a/ttls/client.py
+++ b/ttls/client.py
@@ -381,8 +381,7 @@ class Twinkly(object):
             colour = colour[0]
         if isinstance(colour, Tuple):
             colour = TwinklyColour.from_twinkly_tuple(colour)
-        if not self.is_rgbw():
-            colour.white = None
+
         await self._post(
             "led/color",
             json=colour.as_dict(),


### PR DESCRIPTION
This needs to be removed. 

It leads to a `dataclasses.FrozenInstanceError: cannot assign to field 'white'`

Since the api is so transparent anyway, I think we just need to trust that the clients are doing the right thing for now...