### PR TITLE
Api v2 support

### DIFF
--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -29,6 +29,7 @@ class TwinklyMock(Twinkly):
         if self._api_version == 1:
             return await self._get_v1(endpoint, **kwargs)
         return await self._get_v2(endpoint, **kwargs)
+
     async def _get_v1(self, endpoint: str, **kwargs) -> Any:
         if endpoint == "gestalt":
             return {
@@ -67,90 +68,51 @@ class TwinklyMock(Twinkly):
     async def _get_v2(self, endpoint: str, **kwargs) -> Any:
         if endpoint == "gestalt":
             return {
-                "artnet_en" : False,
-                "cloud" : True,
-                "device_config" : {
-                   "drv_params" : {
-                      "t0h" : 7000,
-                      "t0l" : 2000,
-                      "t1h" : 3500,
-                      "t1l" : 5500,
-                      "tendh" : 4000,
-                      "tendl" : 12500
-                   },
-                   "led_drv" : "d9865c",
-                   "led_id" : 136,
-                   "led_profile" : "RGBW",
-                   "ports" : [
-                      {
-                         "port_id" : 0,
-                         "strings" : [
-                            {
-                               "len" : 250,
-                               "start" : 1
-                            }
-                         ]
-                      },
-                      {
-                         "port_id" : 1,
-                         "strings" : [
-                            {
-                               "len" : 250,
-                               "start" : 1
-                            }
-                         ]
-                      },
-                      {
-                         "port_id" : 2,
-                         "strings" : [
-                            {
-                               "len" : 250,
-                               "start" : 1
-                            }
-                         ]
-                      },
-                      {
-                         "port_id" : 3,
-                         "strings" : [
-                            {
-                               "len" : 250,
-                               "start" : 1
-                            }
-                         ]
-                      }
-                   ]
+                "artnet_en": False,
+                "cloud": True,
+                "device_config": {
+                    "drv_params": {
+                        "t0h": 7000,
+                        "t0l": 2000,
+                        "t1h": 3500,
+                        "t1l": 5500,
+                        "tendh": 4000,
+                        "tendl": 12500,
+                    },
+                    "led_drv": "d9865c",
+                    "led_id": 136,
+                    "led_profile": "RGBW",
+                    "ports": [
+                        {"port_id": 0, "strings": [{"len": 250, "start": 1}]},
+                        {"port_id": 1, "strings": [{"len": 250, "start": 1}]},
+                        {"port_id": 2, "strings": [{"len": 250, "start": 1}]},
+                        {"port_id": 3, "strings": [{"len": 250, "start": 1}]},
+                    ],
                 },
-                "device_name" : "MockPro",
-                "frame_rate" : 9,
-                "group" : {
-                   "mode" : "none",
-                   "offset" : 0,
-                   "size" : 0,
-                   "uid" : ""
+                "device_name": "MockPro",
+                "frame_rate": 9,
+                "group": {"mode": "none", "offset": 0, "size": 0, "uid": ""},
+                "max_capacity": 6722,
+                "max_movies": 24,
+                "max_playlists": 4,
+                "max_steps": 16,
+                "max_supported_led": 1500,
+                "movie_capacity": 6544,
+                "network": {
+                    "dhcp": True,
+                    "gateway": "192.168.0.0",
+                    "ip": "192.0.2.1",
+                    "netmask": "255.255.255.0",
                 },
-                "max_capacity" : 6722,
-                "max_movies" : 24,
-                "max_playlists" : 4,
-                "max_steps" : 16,
-                "max_supported_led" : 1500,
-                "movie_capacity" : 6544,
-                "network" : {
-                   "dhcp" : True,
-                   "gateway" : "192.168.0.0",
-                   "ip" : "192.0.2.1",
-                   "netmask" : "255.255.255.0"
-                },
-                "number_of_led" : 1000,
-                "osc_en" : False,
-                "poe_en" : True,
-                "product_code" : "TWPROCTRLPLC21",
-                "rest_locked" : False,
-                "result" : {
-                   "code" : 1000
-                },
-                "ui_en" : True,
-                "uptime" : 365688633
-             }
+                "number_of_led": 1000,
+                "osc_en": False,
+                "poe_en": True,
+                "product_code": "TWPROCTRLPLC21",
+                "rest_locked": False,
+                "result": {"code": 1000},
+                "ui_en": True,
+                "uptime": 365688633,
+            }
 
         if endpoint == "device/name":
             # Code should be 1000
@@ -158,12 +120,12 @@ class TwinklyMock(Twinkly):
         if endpoint == "movies":
             # Attribute "movies" is missing from the response
             return {
-                       'size': 4,
-                       'max': 24,
-                       'available_frames': 6544,
-                       'max_capacity': 6722,
-                       'result': {TWINKLY_RETURN_CODE: TWINKLY_RETURN_CODE_OK}
-                    }
+                "size": 4,
+                "max": 24,
+                "available_frames": 6544,
+                "max_capacity": 6722,
+                "result": {TWINKLY_RETURN_CODE: TWINKLY_RETURN_CODE_OK},
+            }
 
         _LOGGER.warning("Endpoint %s not yet implemented")
         return
@@ -205,6 +167,7 @@ class TestTwinklyGeneric(aiounittest.AsyncTestCase):
         with pytest.raises(TwinklyError) as e:
             await self.client_v2.get_saved_movies()
         assert "Invalid response from Twinkly" in str(e.value)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -26,6 +26,10 @@ class TwinklyMock(Twinkly):
 
     async def _get(self, endpoint: str, **kwargs) -> Any:
         _LOGGER.debug("MOCK: GET endpoint %s", endpoint)
+        if self._api_version == 1:
+            return await self._get_v1(endpoint, **kwargs)
+        return await self._get_v2(endpoint, **kwargs)
+    async def _get_v1(self, endpoint: str, **kwargs) -> Any:
         if endpoint == "gestalt":
             return {
                 "product_name": "Twinkly",
@@ -60,6 +64,110 @@ class TwinklyMock(Twinkly):
         _LOGGER.warning("Endpoint %s not yet implemented")
         return
 
+    async def _get_v2(self, endpoint: str, **kwargs) -> Any:
+        if endpoint == "gestalt":
+            return {
+                "artnet_en" : False,
+                "cloud" : True,
+                "device_config" : {
+                   "drv_params" : {
+                      "t0h" : 7000,
+                      "t0l" : 2000,
+                      "t1h" : 3500,
+                      "t1l" : 5500,
+                      "tendh" : 4000,
+                      "tendl" : 12500
+                   },
+                   "led_drv" : "d9865c",
+                   "led_id" : 136,
+                   "led_profile" : "RGBW",
+                   "ports" : [
+                      {
+                         "port_id" : 0,
+                         "strings" : [
+                            {
+                               "len" : 250,
+                               "start" : 1
+                            }
+                         ]
+                      },
+                      {
+                         "port_id" : 1,
+                         "strings" : [
+                            {
+                               "len" : 250,
+                               "start" : 1
+                            }
+                         ]
+                      },
+                      {
+                         "port_id" : 2,
+                         "strings" : [
+                            {
+                               "len" : 250,
+                               "start" : 1
+                            }
+                         ]
+                      },
+                      {
+                         "port_id" : 3,
+                         "strings" : [
+                            {
+                               "len" : 250,
+                               "start" : 1
+                            }
+                         ]
+                      }
+                   ]
+                },
+                "device_name" : "MockPro",
+                "frame_rate" : 9,
+                "group" : {
+                   "mode" : "none",
+                   "offset" : 0,
+                   "size" : 0,
+                   "uid" : ""
+                },
+                "max_capacity" : 6722,
+                "max_movies" : 24,
+                "max_playlists" : 4,
+                "max_steps" : 16,
+                "max_supported_led" : 1500,
+                "movie_capacity" : 6544,
+                "network" : {
+                   "dhcp" : True,
+                   "gateway" : "192.168.0.0",
+                   "ip" : "192.0.2.1",
+                   "netmask" : "255.255.255.0"
+                },
+                "number_of_led" : 1000,
+                "osc_en" : False,
+                "poe_en" : True,
+                "product_code" : "TWPROCTRLPLC21",
+                "rest_locked" : False,
+                "result" : {
+                   "code" : 1000
+                },
+                "ui_en" : True,
+                "uptime" : 365688633
+             }
+
+        if endpoint == "device/name":
+            # Code should be 1000
+            return {"result": {TWINKLY_RETURN_CODE: TWINKLY_RETURN_CODE_OK + 1}}
+        if endpoint == "movies":
+            # Attribute "movies" is missing from the response
+            return {
+                       'size': 4,
+                       'max': 24,
+                       'available_frames': 6544,
+                       'max_capacity': 6722,
+                       'result': {TWINKLY_RETURN_CODE: TWINKLY_RETURN_CODE_OK}
+                    }
+
+        _LOGGER.warning("Endpoint %s not yet implemented")
+        return
+
 
 class TestTwinklyGeneric(aiounittest.AsyncTestCase):
     @classmethod
@@ -67,7 +175,8 @@ class TestTwinklyGeneric(aiounittest.AsyncTestCase):
         logging.basicConfig(level=logging.DEBUG)
 
     def setUp(self):
-        self.client = TwinklyMock(host="192.0.2.1")
+        self.client = TwinklyMock(host="192.0.2.1", api_version=1)
+        self.client_v2 = TwinklyMock(host="192.0.2.1", api_version=2)
 
     async def test_get_details(self):
         res = await self.client.get_details()
@@ -83,6 +192,19 @@ class TestTwinklyGeneric(aiounittest.AsyncTestCase):
             await self.client.get_saved_movies()
         assert "Invalid response from Twinkly" in str(e.value)
 
+    async def test_get_details_v2(self):
+        res = await self.client_v2.get_details()
+        self.assertEqual(res["product_code"], "TWPROCTRLPLC21")
+
+    async def test_validation_error_code_v2(self):
+        with pytest.raises(TwinklyError) as e:
+            await self.client_v2.get_name()
+        assert "Invalid response from Twinkly" in str(e.value)
+
+    async def test_validation_error_string_v2(self):
+        with pytest.raises(TwinklyError) as e:
+            await self.client_v2.get_saved_movies()
+        assert "Invalid response from Twinkly" in str(e.value)
 
 if __name__ == "__main__":
     unittest.main()

--- a/ttls/cli.py
+++ b/ttls/cli.py
@@ -113,10 +113,10 @@ async def command_movie(t: Twinkly, args: argparse.Namespace):
 
 async def command_static(t: Twinkly, args: argparse.Namespace):
     await t.interview()
-    m = re.match(r"(\d+),(\d+),(\d+),?(\d+)?", args.colour)
-    if m is not None:
-        w = int(m.group(4)) if m.group(4) is not None else None
-        rgbw = (int(m.group(1)), int(m.group(2)), int(m.group(3)), w)
+    if m := re.match(r"(\d+),(\d+),(\d+),(\d+)", args.colour):
+        rgbw = (int(m.group(1)), int(m.group(2)), int(m.group(3)), int(m.group(4)))
+    elif m := re.match(r"(\d+),(\d+),(\d+)", args.colour):
+        rgbw = (int(m.group(1)), int(m.group(2)), int(m.group(3)), None)
     else:
         c = TwinklyColour(args.colour)
         rgbw = (int(c.red * 255), int(c.green * 255), int(c.blue * 255), None)

--- a/ttls/cli.py
+++ b/ttls/cli.py
@@ -113,13 +113,14 @@ async def command_movie(t: Twinkly, args: argparse.Namespace):
 
 async def command_static(t: Twinkly, args: argparse.Namespace):
     await t.interview()
-    m = re.match(r"(\d+),(\d+),(\d+)", args.colour)
+    m = re.match(r"(\d+),(\d+),(\d+),?(\d+)?", args.colour)
     if m is not None:
-        rgb = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+        w = int(m.group(4)) if m.group(4) is not None else None
+        rgbw = (int(m.group(1)), int(m.group(2)), int(m.group(3)), w)
     else:
         c = TwinklyColour(args.colour)
-        rgb = (int(c.red * 255), int(c.green * 255), int(c.blue * 255))
-    return await t.set_static_colour(rgb)
+        rgbw = (int(c.red * 255), int(c.green * 255), int(c.blue * 255), None)
+    return await t.set_static_colour(rgbw)
 
 
 async def command_summary(t: Twinkly, args: argparse.Namespace):

--- a/ttls/cli.py
+++ b/ttls/cli.py
@@ -113,17 +113,17 @@ async def command_movie(t: Twinkly, args: argparse.Namespace):
 
 async def command_static(t: Twinkly, args: argparse.Namespace):
     await t.interview()
-    #match on r,g,b or r,g,b,w
+    # match on r,g,b or r,g,b,w
     if m := re.match(r"(\d+),(\d+),(\d+)(?:,(\d+))?", args.colour):
         r = int(m.group(1))
         g = int(m.group(2))
         b = int(m.group(3))
-        #w is optional; convert to int if set
+        # w is optional; convert to int if set
         if w := m.group(4):
             w = int(w)
-        c = TwinklyColour(r,g,b,w)
+        c = TwinklyColour(r, g, b, w)
     else:
-        raise ValueError("Colour argument is not in r,g,b or r,g,b,w format") 
+        raise ValueError("Colour argument is not in r,g,b or r,g,b,w format")
     return await t.set_static_colour(c)
 
 

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -36,7 +36,12 @@ import time
 from itertools import cycle, islice
 from typing import Any, Callable, Optional, Tuple
 
-from aiohttp import ClientResponseError, ClientSession, ClientTimeout, ServerDisconnectedError
+from aiohttp import (
+    ClientResponseError,
+    ClientSession,
+    ClientTimeout,
+    ServerDisconnectedError,
+)
 from aiohttp.web_exceptions import HTTPUnauthorized
 
 from .colours import TwinklyColour, TwinklyColourTuple

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -128,6 +128,8 @@ class Twinkly:
 
     @property
     def base(self) -> str:
+        if self._api_version is None:
+            raise ValueError("api version isn't set")
         return f"http://{self.host}/xled/v{self._api_version}"
 
     @property

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -552,9 +552,8 @@ class Twinkly:
 
     async def get_playlist(self) -> Any:
         """Get the playlist."""
-        if await self.get_api_version() != 1:
-            raise NotImplementedError 
-        return self._valid_response(await self._get("playlist"))
+        endpoint = "playlist" if await self.get_api_version() == 1 else "playlists"
+        return self._valid_response(await self._get(endpoint))
 
     async def get_current_playlist_entry(self) -> Any:
         """Get current playlist."""

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -157,6 +157,7 @@ class Twinkly:
     async def close(self) -> None:
         if not self._shared_session:
             await self._get_session().close()
+            self._session = None
 
     async def interview(self, force: bool | None = False) -> None:
         if len(self._details) == 0 or force:
@@ -166,7 +167,9 @@ class Twinkly:
                 self.default_mode = mode.get("mode")
 
     def _get_session(self):
-        return self._session or ClientSession()
+        if not self._session:
+            self._session = ClientSession() 
+        return self._session
 
     async def _info(self) -> Any:
         _LOGGER.debug("INFO")

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -175,7 +175,7 @@ class Twinkly:
 
     def _get_session(self):
         if not self._session:
-            self._session = ClientSession() 
+            self._session = ClientSession()
         return self._session
 
     async def _info(self) -> Any:
@@ -189,7 +189,7 @@ class Twinkly:
                 _LOGGER.debug("INFO response %d", r.status)
                 return await r.json()
         except (ClientResponseError, ServerDisconnectedError) as e:
-                raise e
+            raise e
 
     async def get_api_version(self) -> int:
         if self._api_version is None:
@@ -199,7 +199,7 @@ class Twinkly:
     async def detect_api_version(self) -> int:
         try:
             info = await self._info()
-            return int(info['api']['min_version'].split('.')[0])
+            return int(info["api"]["min_version"].split(".")[0])
         except (ClientResponseError, ServerDisconnectedError) as e:
             _LOGGER.debug(e)
             return 1
@@ -326,11 +326,17 @@ class Twinkly:
         return self._valid_response(await self._get("reset"))
 
     async def get_network_status(self) -> Any:
-        endpoint = "network/status" if await self.get_api_version() == 1 else "network/eth/status"
+        endpoint = (
+            "network/status"
+            if await self.get_api_version() == 1
+            else "network/eth/status"
+        )
         return self._valid_response(await self._get(endpoint))
 
     async def get_firmware_version(self) -> Any:
-        endpoint = "fw/version" if await self.get_api_version() == 1 else "fw/ct1/version"
+        endpoint = (
+            "fw/version" if await self.get_api_version() == 1 else "fw/ct1/version"
+        )
         return self._valid_response(await self._get(endpoint))
 
     async def get_details(self) -> Any:
@@ -352,19 +358,21 @@ class Twinkly:
         return self._valid_response(await self._get("led/out/brightness"))
 
     async def set_brightness(self, percent: int) -> Any:
-        args={"value": percent, "type": "A"}
+        args = {"value": percent, "type": "A"}
         if await self.get_api_version() >= 2:
             args["mode"] = "enabled"
-        return await self._post(
-            "led/out/brightness", json=args
-        )
+        return await self._post("led/out/brightness", json=args)
 
     async def get_mode(self) -> Any:
-        endpoint = "led/mode" if await self.get_api_version() == 1 else "application/mode"
+        endpoint = (
+            "led/mode" if await self.get_api_version() == 1 else "application/mode"
+        )
         return self._valid_response(await self._get(endpoint))
 
     async def set_mode(self, mode: str) -> Any:
-        endpoint = "led/mode" if await self.get_api_version() == 1 else "application/mode"
+        endpoint = (
+            "led/mode" if await self.get_api_version() == 1 else "application/mode"
+        )
         return await self._post(endpoint, json={"mode": mode})
 
     async def get_mqtt(self) -> Any:
@@ -407,7 +415,7 @@ class Twinkly:
 
     async def get_movie_config(self) -> Any:
         if await self.get_api_version() != 1:
-            raise NotImplementedError 
+            raise NotImplementedError
         return self._valid_response(await self._get("led/movie/config"))
 
     async def set_movie_config(self, data: dict) -> Any:
@@ -507,7 +515,7 @@ class Twinkly:
 
     async def get_current_music_driver(self) -> Any:
         if await self.get_api_version() != 1:
-            raise NotImplementedError 
+            raise NotImplementedError
         return self._valid_response(await self._get("music/drivers/current"))
 
     async def set_current_music_driver(self, driver_name: str) -> Any:
@@ -547,13 +555,13 @@ class Twinkly:
     async def get_predefined_effects(self) -> Any:
         """Get the list of predefined effects."""
         if await self.get_api_version() != 1:
-            raise NotImplementedError 
+            raise NotImplementedError
         return self._valid_response(await self._get("led/effects"))
 
     async def get_current_predefined_effect(self) -> Any:
         """Get current effect."""
         if await self.get_api_version() != 1:
-            raise NotImplementedError 
+            raise NotImplementedError
         return self._valid_response(await self._get("led/effects/current"))
 
     async def set_current_predefined_effect(self, effect_id: int) -> None:
@@ -571,7 +579,7 @@ class Twinkly:
     async def get_current_playlist_entry(self) -> Any:
         """Get current playlist."""
         if await self.get_api_version() != 1:
-            raise NotImplementedError 
+            raise NotImplementedError
         return self._valid_response(await self._get("playlist/current"))
 
     async def set_current_playlist_entry(self, entry_id: int) -> None:
@@ -585,11 +593,8 @@ class Twinkly:
         self, response: dict[Any, Any], check_for: str | None = None
     ) -> dict[Any, Any]:
         """Validate twinkly-responses from the API."""
-        if (
-            response
-            and  self._api_version >= 2
-        ):
-            result = response.get('result')
+        if response and self._api_version >= 2:
+            result = response.get("result")
         else:
             result = response
         if (

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -319,7 +319,8 @@ class Twinkly:
         return self._valid_response(await self._get("network/status"))
 
     async def get_firmware_version(self) -> Any:
-        return self._valid_response(await self._get("fw/version"))
+        endpoint = "fw/version" if await self.get_api_version() == 1 else "fw/ct1/version"
+        return self._valid_response(await self._get(endpoint))
 
     async def get_details(self) -> Any:
         return self._valid_response(await self._get("gestalt"))

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -307,10 +307,12 @@ class Twinkly:
         await self._post("verify", json={})
 
     async def get_name(self) -> Any:
-        return self._valid_response(await self._get("device_name"))
+        endpoint = "device_name" if await self.get_api_version() == 1 else "device/name"
+        return self._valid_response(await self._get(endpoint))
 
     async def set_name(self, name: str) -> Any:
-        return await self._post("device_name", json={"name": name})
+        endpoint = "device_name" if await self.get_api_version() == 1 else "device/name"
+        return await self._post(endpoint, json={"name": name})
 
     async def reset(self) -> Any:
         return self._valid_response(await self._get("reset"))

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -401,6 +401,8 @@ class Twinkly:
             self._socket.sendto(header + bytes(payload), (self.host, self._rt_port))
 
     async def get_movie_config(self) -> Any:
+        if await self.get_api_version() != 1:
+            raise NotImplementedError 
         return self._valid_response(await self._get("led/movie/config"))
 
     async def set_movie_config(self, data: dict) -> Any:
@@ -491,6 +493,8 @@ class Twinkly:
         return await self._post("music/drivers/current", json={"action": "prev"})
 
     async def get_current_music_driver(self) -> Any:
+        if await self.get_api_version() != 1:
+            raise NotImplementedError 
         return self._valid_response(await self._get("music/drivers/current"))
 
     async def set_current_music_driver(self, driver_name: str) -> Any:
@@ -529,10 +533,14 @@ class Twinkly:
 
     async def get_predefined_effects(self) -> Any:
         """Get the list of predefined effects."""
+        if await self.get_api_version() != 1:
+            raise NotImplementedError 
         return self._valid_response(await self._get("led/effects"))
 
     async def get_current_predefined_effect(self) -> Any:
         """Get current effect."""
+        if await self.get_api_version() != 1:
+            raise NotImplementedError 
         return self._valid_response(await self._get("led/effects/current"))
 
     async def set_current_predefined_effect(self, effect_id: int) -> None:
@@ -544,10 +552,14 @@ class Twinkly:
 
     async def get_playlist(self) -> Any:
         """Get the playlist."""
+        if await self.get_api_version() != 1:
+            raise NotImplementedError 
         return self._valid_response(await self._get("playlist"))
 
     async def get_current_playlist_entry(self) -> Any:
         """Get current playlist."""
+        if await self.get_api_version() != 1:
+            raise NotImplementedError 
         return self._valid_response(await self._get("playlist/current"))
 
     async def set_current_playlist_entry(self, entry_id: int) -> None:

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -187,9 +187,9 @@ class Twinkly:
                 raise e
 
     async def get_api_version(self) -> int:
-        if self._api_version is not None:
-            return self._api_version
-        return await self.detect_api_version()
+        if self._api_version is None:
+            self._api_version = await self.detect_api_version()
+        return self._api_version
 
     async def detect_api_version(self) -> int:
         try:
@@ -200,8 +200,7 @@ class Twinkly:
             return 1
 
     async def _post(self, endpoint: str, **kwargs) -> Any:
-        if self._api_version is None:
-            self._api_version = await self.get_api_version()
+        await self.get_api_version()
         await self.ensure_token()
         _LOGGER.debug("POST endpoint %s", endpoint)
         if "json" in kwargs:
@@ -227,8 +226,7 @@ class Twinkly:
                 raise e
 
     async def _get(self, endpoint: str, **kwargs) -> Any:
-        if self._api_version is None:
-            self._api_version = await self.get_api_version()
+        await self.get_api_version()
         await self.ensure_token()
         _LOGGER.debug("GET endpoint %s", endpoint)
         headers = kwargs.pop("headers", self._headers)

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -430,11 +430,18 @@ class Twinkly:
             colour = colour[0]
         if isinstance(colour, Tuple):
             colour = TwinklyColour.from_twinkly_tuple(colour)
-        await self._post(
-            "led/color",
-            json=colour.as_dict(),
-        )
-        await self.set_mode("color")
+        if await self.get_api_version() == 1:
+            await self._post(
+                "led/color",
+                json=colour.as_dict(),
+            )
+            await self.set_mode("color")
+        else:
+            await self.set_mode("color")
+            await self._post(
+                "led/color",
+                json=colour.as_dict(),
+            )
 
     async def set_cycle_colours(
         self,

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -318,7 +318,8 @@ class Twinkly:
         return self._valid_response(await self._get("reset"))
 
     async def get_network_status(self) -> Any:
-        return self._valid_response(await self._get("network/status"))
+        endpoint = "network/status" if await self.get_api_version() == 1 else "network/eth/status"
+        return self._valid_response(await self._get(endpoint))
 
     async def get_firmware_version(self) -> Any:
         endpoint = "fw/version" if await self.get_api_version() == 1 else "fw/ct1/version"

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -178,7 +178,7 @@ class Twinkly:
             self._session = ClientSession() 
         return self._session
 
-       async def _info(self) -> Any:
+    async def _info(self) -> Any:
         _LOGGER.debug("INFO")
         try:
             async with self._get_session().get(

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -36,7 +36,7 @@ import time
 from itertools import cycle, islice
 from typing import Any, Callable, Optional, Tuple
 
-from aiohttp import ClientResponseError, ClientSession, ClientTimeout
+from aiohttp import ClientResponseError, ClientSession, ClientTimeout, ServerDisconnectedError
 from aiohttp.web_exceptions import HTTPUnauthorized
 
 from .colours import TwinklyColour, TwinklyColourTuple
@@ -173,7 +173,7 @@ class Twinkly:
             self._session = ClientSession() 
         return self._session
 
-    async def _info(self) -> Any:
+       async def _info(self) -> Any:
         _LOGGER.debug("INFO")
         try:
             async with self._get_session().get(
@@ -183,7 +183,7 @@ class Twinkly:
             ) as r:
                 _LOGGER.debug("INFO response %d", r.status)
                 return await r.json()
-        except ClientResponseError as e:
+        except (ClientResponseError, ServerDisconnectedError) as e:
                 raise e
 
     async def get_api_version(self) -> int:
@@ -195,7 +195,7 @@ class Twinkly:
         try:
             info = await self._info()
             return int(info['api']['min_version'].split('.')[0])
-        except ClientResponseError as e:
+        except (ClientResponseError, ServerDisconnectedError) as e:
             _LOGGER.debug(e)
             return 1
 

--- a/ttls/client.py
+++ b/ttls/client.py
@@ -198,11 +198,21 @@ class Twinkly:
 
     async def detect_api_version(self) -> int:
         try:
-            info = await self._info()
-            return int(info["api"]["min_version"].split(".")[0])
-        except (ClientResponseError, ServerDisconnectedError) as e:
-            _LOGGER.debug(e)
+            self._api_version = 1
+            _ = await self.get_details()
             return 1
+        except (ClientResponseError, TwinklyError):
+            pass
+
+        try:
+            self._api_version = 2
+            _ = await self.get_details()
+            return 2
+        except (ClientResponseError, TwinklyError):
+            pass
+
+        self._api_version = None
+        return None
 
     async def _post(self, endpoint: str, **kwargs) -> Any:
         await self.get_api_version()


### PR DESCRIPTION
Hi! I've never done a pull request before so please let me know if there is anything I can do that would be more helpful. I recently acquired a Twinkly Pro controller and discovered that Home Assistant would not talk to it. Using tcpdump I eventually determined that it uses a v2 RESTful interface with only apparently minor changes from v1. I have not yet added support for 'movies' stuff, but querying the basic data, setting the brightness, setting a fixed colour, and turning it on or off all works.  I attempted to ensure I didn't break any v1 devices, but as I don't currently have any available I can't be certain.