### PR TITLE
Adds v3 realtime frame support

### DIFF
--- a/ttls/client.py
+++ b/ttls/client.py
@@ -394,6 +394,19 @@ class Twinkly:
                 payload.extend(list(x))
             self._socket.sendto(header + bytes(payload), (self.host, self._rt_port))
 
+    async def send_frame_3(self, frame: TwinklyFrame) -> None:
+        await self.interview()
+        if len(frame) != self.length:
+            raise ValueError("Invalid frame length")
+        token = await self.ensure_token()
+        frame_segments = [frame[i : i + RT_PAYLOAD_MAX_LIGHTS] for i in range(0, len(frame), RT_PAYLOAD_MAX_LIGHTS)]
+        for i in range(0, len(frame_segments)):
+            header = bytes([0x03]) + bytes(base64.b64decode(token)) + bytes([0, 0]) + bytes([i])
+            payload = []
+            for x in frame_segments[i]:
+                payload.extend(list(x))
+            self._socket.sendto(header + bytes(payload), (self.host, self._rt_port))            
+
     async def get_movie_config(self) -> Any:
         if await self.get_api_version() != 1:
             raise NotImplementedError


### PR DESCRIPTION
I do not know exactly what [send_frame_2](https://github.com/jschlyter/ttls/blob/bec1d809445bcb0ea9201eb8bd10c8efa2805003/ttls/client.py#L384) is trying to do exactly. Based on its name I'd guess it is trying to implement [Version 2 of the Real time LED UDP datagram format](https://xled-docs.readthedocs.io/en/latest/protocol_details.html#real-time-led-udp-datagram-format)](https://xled-docs.readthedocs.io/en/latest/protocol_details.html#version-2), but looking at its actual implementation it looks more like [Version 3](https://xled-docs.readthedocs.io/en/latest/protocol_details.html#version-3) although it is not entirely correct then either. For V3 in the [header](https://github.com/jschlyter/ttls/blob/bec1d809445bcb0ea9201eb8bd10c8efa2805003/ttls/client.py#L391) it should not be using `len(frame_segments)`, it should simply be a hardcoded `0x03` instead.

In any case, what I did here is that I left `send_frame_2` as-is, but also made a copy of it named `send_frame_3` and then in this function I fixed the header to be `0x03`.

I have verified this to work correctly with the Twinkly Squares which I own.