### PR TITLE
Add support for cold white in color mode

### DIFF
--- a/tests/test_colours.py
+++ b/tests/test_colours.py
@@ -26,3 +26,12 @@ class TestTwinklyColours(unittest.TestCase):
 
         rgbw = TwinklyColour.from_twinkly_tuple((1, 2, 3, 4))
         self.assertEqual(rgbw.as_dict(), {"blue": 4, "green": 3, "red": 2, "white": 1})
+
+    def test_colours_rgbww(self):
+        col = TwinklyColour(1, 2, 3, 4, 5)
+        self.assertEqual(col.as_twinkly_tuple(), (5, 4, 1, 2, 3))
+        self.assertEqual(tuple(col), (1, 2, 3, 4, 5))
+        self.assertEqual(col.as_dict(), {"blue": 3, "green": 2, "red": 1, "white": 4, "cold_white": 5})
+
+        rgbw = TwinklyColour.from_twinkly_tuple((1, 2, 3, 4, 5))
+        self.assertEqual(rgbw.as_dict(), {"blue": 5, "green": 4, "red": 3, "white": 2, "cold_white": 1})

--- a/ttls/cli.py
+++ b/ttls/cli.py
@@ -113,17 +113,17 @@ async def command_movie(t: Twinkly, args: argparse.Namespace):
 
 async def command_static(t: Twinkly, args: argparse.Namespace):
     await t.interview()
-    # match on r,g,b or r,g,b,w
-    if m := re.match(r"(\d+),(\d+),(\d+)(?:,(\d+))?", args.colour):
+    # match on r,g,b, r,g,b,w or r,g,b,w,cw
+    if m := re.match(r"(\d+),(\d+),(\d+)(?:,(\d+)(?:,(\d+))?)?", args.colour):
         r = int(m.group(1))
         g = int(m.group(2))
         b = int(m.group(3))
-        # w is optional; convert to int if set
-        if w := m.group(4):
-            w = int(w)
-        c = TwinklyColour(r, g, b, w)
+        # w and cw are optional; convert to int if set
+        w = int(m.group(4)) if m.group(4) is not None else None
+        cw = int(m.group(5)) if m.group(5) is not None else None
+        c = TwinklyColour(r, g, b, w, cw)
     else:
-        raise ValueError("Colour argument is not in r,g,b or r,g,b,w format")
+        raise ValueError("Colour argument is not in r,g,b, r,g,b,w or r,g,b,w,cw format")
     return await t.set_static_colour(c)
 
 

--- a/ttls/colours.py
+++ b/ttls/colours.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
 
 ColourDict = dict[str, int]
-ColourTuple = tuple[int, int, int] | tuple[int, int, int, int]
-TwinklyColourTuple = tuple[int, int, int] | tuple[int, int, int, int]
+ColourTuple = tuple[int, int, int] | tuple[int, int, int, int] | tuple[int, int, int, int, int]
+TwinklyColourTuple = tuple[int, int, int] | tuple[int, int, int, int] | tuple[int, int, int, int, int]
 
 
 @dataclass(frozen=True)
@@ -11,17 +11,22 @@ class TwinklyColour:
     green: int
     blue: int
     white: int | None = None
+    cold_white: int | None = None
 
     def as_twinkly_tuple(self) -> TwinklyColourTuple:
-        """Convert TwinklyColour to a tuple as used by Twinkly: (R,G,B) or (W,R,G,B)"""
-        if self.white is not None:
+        """Convert TwinklyColour to a tuple as used by Twinkly: (R,G,B), (W,R,G,B) or (W,W,R,G,B)"""
+        if self.cold_white is not None and self.white is not None:
+            return (self.cold_white, self.white, self.red, self.green, self.blue)
+        elif self.white is not None:
             return (self.white, self.red, self.green, self.blue)
         else:
             return (self.red, self.green, self.blue)
 
     def as_tuple(self) -> ColourTuple:
-        """Convert TwinklyColour to a tuple: (R,G,B) or (R,G,B,W)"""
-        if self.white is not None:
+        """Convert TwinklyColour to a tuple: (R,G,B), (R,G,B,W) or (R,G,B,W,W)"""
+        if self.cold_white is not None and self.white is not None:
+            return (self.red, self.green, self.blue, self.white, self.cold_white)
+        elif self.white is not None:
             return (self.red, self.green, self.blue, self.white)
         else:
             return (self.red, self.green, self.blue)
@@ -31,18 +36,23 @@ class TwinklyColour:
 
     def as_dict(self) -> ColourDict:
         """Convert TwinklyColour to a dict wth color names used by set-led functions."""
-        if self.white is not None:
+        if self.cold_white is not None and self.white is not None:
             return {
                 "red": self.red,
                 "green": self.green,
                 "blue": self.blue,
                 "white": self.white,
+                "cold_white": self.cold_white,
             }
+        elif self.white is not None:
+            return {"red": self.red, "green": self.green, "blue": self.blue, "white": self.white}
         else:
             return {"red": self.red, "green": self.green, "blue": self.blue}
 
     @classmethod
     def from_twinkly_tuple(cls, t):
+        if len(t) == 5:
+            return cls(red=t[2], green=t[3], blue=t[4], white=t[1], cold_white=t[0])
         if len(t) == 4:
             return cls(red=t[1], green=t[2], blue=t[3], white=t[0])
         elif len(t) == 3:

--- a/ttls/colours.py
+++ b/ttls/colours.py
@@ -13,8 +13,12 @@ class TwinklyColour:
     white: int | None = None
     cold_white: int | None = None
 
+    def __post_init__(self):
+        if self.cold_white is not None and self.white is None:
+            raise ValueError("cold_white requires white to be set")
+
     def as_twinkly_tuple(self) -> TwinklyColourTuple:
-        """Convert TwinklyColour to a tuple as used by Twinkly: (R,G,B), (W,R,G,B) or (W,W,R,G,B)"""
+        """Convert TwinklyColour to a tuple as used by Twinkly: (R,G,B), (W,R,G,B) or (CW,W,R,G,B)"""
         if self.cold_white is not None and self.white is not None:
             return (self.cold_white, self.white, self.red, self.green, self.blue)
         elif self.white is not None:
@@ -23,7 +27,7 @@ class TwinklyColour:
             return (self.red, self.green, self.blue)
 
     def as_tuple(self) -> ColourTuple:
-        """Convert TwinklyColour to a tuple: (R,G,B), (R,G,B,W) or (R,G,B,W,W)"""
+        """Convert TwinklyColour to a tuple: (R,G,B), (R,G,B,W) or (R,G,B,W,CW)"""
         if self.cold_white is not None and self.white is not None:
             return (self.red, self.green, self.blue, self.white, self.cold_white)
         elif self.white is not None:

--- a/ttls/colours.py
+++ b/ttls/colours.py
@@ -41,7 +41,7 @@ class TwinklyColour:
             "green": self.green,
             "blue": self.blue,
             **({"white": self.white} if self.white is not None else {}),
-            **({"cold_white": self.cold_white} if self.cold_white is not None else {})
+            **({"cold_white": self.cold_white} if self.cold_white is not None else {}),
         }
 
     @classmethod

--- a/ttls/colours.py
+++ b/ttls/colours.py
@@ -36,25 +36,22 @@ class TwinklyColour:
 
     def as_dict(self) -> ColourDict:
         """Convert TwinklyColour to a dict wth color names used by set-led functions."""
-        if self.cold_white is not None and self.white is not None:
-            return {
-                "red": self.red,
-                "green": self.green,
-                "blue": self.blue,
-                "white": self.white,
-                "cold_white": self.cold_white,
-            }
-        elif self.white is not None:
-            return {"red": self.red, "green": self.green, "blue": self.blue, "white": self.white}
-        else:
-            return {"red": self.red, "green": self.green, "blue": self.blue}
+        return {
+            "red": self.red,
+            "green": self.green,
+            "blue": self.blue,
+            **({"white": self.white} if self.white is not None else {}),
+            **({"cold_white": self.cold_white} if self.cold_white is not None else {})
+        }
 
     @classmethod
     def from_twinkly_tuple(cls, t):
-        if len(t) == 5:
-            return cls(red=t[2], green=t[3], blue=t[4], white=t[1], cold_white=t[0])
-        if len(t) == 4:
-            return cls(red=t[1], green=t[2], blue=t[3], white=t[0])
-        elif len(t) == 3:
-            return cls(red=t[0], green=t[1], blue=t[2])
-        raise TypeError("Unknown colour format")
+        match len(t):
+            case 5:
+                return cls(red=t[2], green=t[3], blue=t[4], white=t[1], cold_white=t[0])
+            case 4:
+                return cls(red=t[1], green=t[2], blue=t[3], white=t[0])
+            case 3:
+                return cls(red=t[0], green=t[1], blue=t[2])
+            case _:
+                raise TypeError("Unknown colour format")


### PR DESCRIPTION
The Permanent Lights have a cold white led, this PR adds the support to control that in color mode.

A few notes to consider:
- The cold white channel is only addressable since firmware v2.10.0
- All the color channels must be specified when using the cold white otherwise the other channels might retain the old value when switching from an RGB/W color to an RGBWW one (eg. when I switch from r=0, g=0, b=0, white=255 to r=0, g=0, b=0, cold_white=255 the warm white channel remains to 255)
- The Permanent Lights are still an RGBW product, RGBWW was not implemented as a full fledged led profile. For this reason when working with frames, they should be constructed without the cold white channel whether in realtime or when working with movies



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a fifth, independent cool-white channel in color objects while preserving 3- and 4-channel behavior.
  * CLI accepts an expanded five-component color format and updates validation messaging.

* **Tests**
  * Added tests for 5-color serialization/deserialization, iteration/mapping order, and backward compatibility with 3/4-channel inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->