### PR TITLE
Raise the default request timeout to 10 seconds

### DIFF
--- a/ttls/client.py
+++ b/ttls/client.py
@@ -102,7 +102,15 @@ TWINKLY_MUSIC_DRIVERS = {
 TWINKLY_RETURN_CODE = "code"
 TWINKLY_RETURN_CODE_OK = 1000
 
-DEFAULT_TIMEOUT = 3
+# Twinkly devices are commonly polled on an interval, and their radio idles in
+# between. The first request after an idle period has to wake it, and three
+# seconds - which covers connection setup as well as the response - is often
+# not enough. Measured across three devices polled every 30 seconds, the first
+# request of each cycle timed out 61% of the time at 3 seconds, while every
+# later request in the same cycle answered in well under a second. Responses
+# over three seconds happen in normal use too: a get_current_movie() on a
+# device rendering a movie was observed answering in 5.003 seconds.
+DEFAULT_TIMEOUT = 10
 
 
 class Twinkly:


### PR DESCRIPTION
`ClientTimeout(total=3)` covers connection setup as well as the response, and Twinkly devices are usually polled on an interval with their radio idling in between. The first request after an idle period has to wake the radio, and three seconds is often not enough.

Measured across three devices polled every 30 seconds, counting requests that never received a response, grouped by endpoint in the order the caller sends them:

| endpoint | position in cycle | timed out |
|---|---|---|
| `gestalt` | 1st | **61.4 %** |
| `led/out/brightness` | 2nd | 11.4 % |
| `led/mode` | 3rd | 2.9 % |
| `movies` | 4th | 3.3 % |
| `movies/current` | 5th | 13.3 % |

It is the *first* request that fails, not the last — once the radio is awake the device answers in well under a second. Responses over three seconds also occur in normal use: a `get_current_movie()` on a device rendering a movie was observed answering successfully in **5.003 s**.

Downstream this shows up as devices flapping between available and unavailable. In Home Assistant, which constructs the client without a timeout and so inherits this default, three lights alternated roughly 1070 times per device per day; raising the timeout took that to zero over matched 24-minute windows (78.2/h → 0.0/h).

Callers that want the previous behaviour can still pass `timeout=3` explicitly.

I have opened the equivalent change in Home Assistant as home-assistant/core#179140, passing an explicit timeout, so the two are independent — either alone resolves it. Fixing the default here seems the better home for it, since any caller that doesn't think about timeouts gets the same problem.

Related: home-assistant/core#160154, which was reported by three users and closed as stale without a diagnosis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default connection timeout to improve reliability when devices take longer to wake up or respond.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->